### PR TITLE
Maintain old base URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ description: > # this means to ignore newlines until "baseurl:"
   vehicle dynamics from scratch
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://kktse.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+permalink: /jekyll/update/:year/:month/:day/:title:output_ext
 repository: kktse/kktse.github.io
 github_username: kktse
 linkedin_username: ktse


### PR DESCRIPTION
* #11 broke the URL path structure
  * Jekyll defaults to `permalink: /:categories/:year/:month/:day/:title:output_ext`
* It would be useful to not break EVERY link that anyone has ever copy/pasta'd