### PR TITLE
Fix unit typo for inertia

### DIFF
--- a/_posts/2018-09-18-single-track-bicycle.markdown
+++ b/_posts/2018-09-18-single-track-bicycle.markdown
@@ -2,13 +2,11 @@
 layout: post
 title:  "Lateral Dynamics of a Linear Single-Track Vehicle"
 date:   2018-09-18 19:15:00 -0400
-modified_date: 2020-08-25
+modified_date: 2020-10-15
 categories: [vehicle dynamics, simulation]
 ---
 
-<script type="text/javascript" async
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">
-</script>
+{% include mathjax.html %}
 
 ## Introduction
 
@@ -64,7 +62,7 @@ For a derivation using work-energy methods, please refer to Chapter 1.3, _Tyre
 
 #### Vehicle Properties
 * $$m$$ represents the vehicle mass [$$kg$$]
-* $$I$$ represents the vehicle yaw inertia [$$kg/m^2$$]
+* $$I$$ represents the vehicle yaw inertia [$$kg \cdot m^2$$]
 * $$l_a$$ represents the length from the chassis centre-of-gravity to the front axle [$$m$$]
 * $$l_b$$ represents the length from the chassis centre-of-gravity to the rear axle [$$m$$]
 * $$W_f$$ represents the vertical load on the front axle [$$N$$]


### PR DESCRIPTION
* Fix typo for units of inertia (kg / m^2 -> kg * m^2)
* Bump the edit date
* Use the mathjax template

If you _really_ need help figuring this out: https://en.wikipedia.org/wiki/Moment_of_inertia

## Before
![Screenshot from 2020-10-15 18-15-48](https://user-images.githubusercontent.com/4438551/96191659-8af3e600-0f12-11eb-8f74-2d04ec042405.png)

## After
![Screenshot from 2020-10-15 18-16-01](https://user-images.githubusercontent.com/4438551/96191662-8f200380-0f12-11eb-88b2-bc765d8920b1.png)
