### PR TITLE
Cornering compliance and understeer unit fixes

### DIFF
--- a/_posts/2018-11-26-understeer-gradient-identification.markdown
+++ b/_posts/2018-11-26-understeer-gradient-identification.markdown
@@ -41,8 +41,8 @@ Where:
 * $$\delta$$ is the steering angle [rad]
 * $$L$$ is the wheelbase of the car [m]
 * $$R$$ is the radius of the turn [m]
-* $$a_y$$ is the lateral acceleration [g]
-* $$K$$ is the understeer gradient [rad/g]
+* $$a_y$$ is the lateral acceleration [m/s<sup>2</sup>]
+* $$K$$ is the understeer gradient [rad/m/s<sup>2</sup>]
 
 Understeer can be measured by means of an understeer gradient test. For our
 purposes, we perform a constant speed test whereby the vehicle is kept at a

--- a/_posts/2018-11-26-understeer-gradient-identification.markdown
+++ b/_posts/2018-11-26-understeer-gradient-identification.markdown
@@ -41,8 +41,8 @@ Where:
 * $$\delta$$ is the steering angle [rad]
 * $$L$$ is the wheelbase of the car [m]
 * $$R$$ is the radius of the turn [m]
-* $$a_y$$ is the lateral acceleration [m/s<sup>2</sup>]
-* $$K$$ is the understeer gradient [rad/m/s<sup>2</sup>]
+* $$a_y$$ is the lateral acceleration [g]
+* $$K$$ is the understeer gradient [rad/g]
 
 Understeer can be measured by means of an understeer gradient test. For our
 purposes, we perform a constant speed test whereby the vehicle is kept at a

--- a/_posts/2019-01-06-cornering-compliance-identification.markdown
+++ b/_posts/2019-01-06-cornering-compliance-identification.markdown
@@ -51,11 +51,12 @@ acceleration is the understeer gradient.
 $$\delta = \frac{L}{R} + K a_y$$
 
 Where:
+
 * $$\delta$$ is the steering angle [$$rad$$]
 * $$L$$ is the wheelbase of the car [$$m$$]
 * $$R$$ is the radius of the turn [$$m$$]
 * $$a_y$$ is the lateral acceleration [$$m/s^2$$]
-* $$K$$ is the understeer gradient [$$rad/(m/s^2)$$]
+* $$K$$ is the understeer gradient [$$\frac{rad}{m/s^2}$$]
 
 Equivalently, the understeering tendency can be described as the difference in
 the front and rear slip angles.
@@ -63,6 +64,7 @@ the front and rear slip angles.
 $$\delta = \frac{L}{R} + (\alpha_f - \alpha_r)$$
 
 Where:
+
 * $$\alpha_f$$ represents the front axle effective slip angle [$$rad$$]
 * $$\alpha_r$$ represents the rear axle effective slip angle [$$rad$$]
 
@@ -79,6 +81,7 @@ $$m_f a_y = \alpha_f C_f$$
 $$m_r a_y = \alpha_r C_r$$
 
 Where:
+
 * $$m_f$$ represents the equivalent mass of the front axle [$$kg$$]
 * $$m_r$$ represents the equivalent mass of the rear axle [$$kg$$]
 * $$C_f$$ represents the front axle effective cornering stiffness [$$N/rad$$]
@@ -96,6 +99,7 @@ the understeer gradient.
 $$K = \frac{m_f}{C_f} - \frac{m_r}{C_r}$$
 
 Where:
+
 * $$D_f$$ represents the front axle cornering compliance [$$\frac{rad}{m/s^2}$$]
 * $$D_r$$ represents the rear axle cornering compliance [$$\frac{rad}{m/s^2}$$]
 
@@ -104,30 +108,6 @@ the front and rear cornering compliances. This definition is mathematically
 consistent with the earlier definition of the understeer gradient. Noteworthy
 of mention is the exclusion of the steer angle term in the cornering compliance
 definition of the  understeer gradient.
-
-As an aside, you will commonly find the following definition for cornering
-compliance in literature. The unit conversion is to $$rad/g$$ is implied
-through the use of $$slugs$$ and $$lbs$$.
-
-$$D = \frac{W}{C} = \frac{mg}{C}$$
-
-Where:
-* $$D$$ represents the axle cornering compliance [$$rad/g$$]
-* $$W$$ represents the vehicle weight [$$slugs$$]
-* $$C$$ represents the axle effective cornering stiffness [$$lbs/rad$$]
-
-Equivalently using SI units, this expands and simplifies to the following
-equation.
-
-$$D = \frac{mg}{Cg} = \frac{m}{C}$$
-
-Where:
-* $$D$$ represents the axle cornering compliance [$$rad/m/s^2$$]
-* $$m$$ is the axle mass [$$kg$$]
-* $$g$$ is the earth gravitational constant [$$m/s^2$$]
-* $$C$$ is the axle effective cornering stiffness [$$N/rad$$]
-* $$W$$ represents the vehicle weight [$$slugs$$]
-* $$C$$ represents the axle effective cornering stiffness [$$lbs/rad$$]
 
 # Experimental Setup
 ![ddt_civicsi](/assets/images/2019-01-06/civicsi_ddt_pits.jpg)
@@ -159,13 +139,13 @@ an unsafe manner. Do not perform this test in an uncontrolled area._
 # Vehicle Parameters
 The following vehicle parameters are assumed for the vehicle-under-test:
 
-| Symbol | Value | Unit | Description |
-| ------ | ----- | ---- | ----------- |
-| $$a$$  | 0.996 | m    | Distance from CG to front axle |
-| $$b$$  | 1.624 | m    | Distance from CG to rear axle |
-| $$m$$  | 1450  | kg   | Vehicle mass |
-| $$I$$  | 2345  | kg m<sup>2</sup> | Vehicle yaw inertia |
-| $$K$$  | 5.5   | deg/g | Understeer gradient (as measured) |
+| Symbol | Value | Unit             | Description                       |
+| ------ | ----- | ---------------- | --------------------------------- |
+| $$a$$  | 0.996 | m                | Distance from CG to front axle    |
+| $$b$$  | 1.624 | m                | Distance from CG to rear axle     |
+| $$m$$  | 1450  | kg               | Vehicle mass                      |
+| $$I$$  | 2345  | kg m<sup>2</sup> | Vehicle yaw inertia               |
+| $$K$$  | 5.5   | deg/g            | Understeer gradient (as measured) |
 
 # Results
 The system identification yields the following cornering compliances:
@@ -212,13 +192,13 @@ to provide useful information about the vehicle. The ability to generalize the
 vehicle response in a simulation is still an extremely powerful tool in analyzing
 and assessing handling performance.
 
-
 _A big thank you to OTA competitor Joseph Yang in the #551 2012 Honda Civic Si
 for performing the pulse steer test and for providing the data used the
 analysis. This article would not be possible without the support of Joseph Yang
 and his sponsors._
 
 # References
+
 1. Milliken, William F., and Douglas L. Milliken. _Race car vehicle dynamics_. Vol. 400. Warrendale: Society of Automotive Engineers, 1995.
 2. Dixon, John. Tires, suspension and handling. SAE, 1996.
 3. Bundorf, R. Thomas, and Ronald L. Leffert. The cornering compliance concept for description of vehicle directional control properties. No. 760713. SAE Technical Paper, 1976.

--- a/_posts/2019-01-06-cornering-compliance-identification.markdown
+++ b/_posts/2019-01-06-cornering-compliance-identification.markdown
@@ -2,6 +2,7 @@
 layout: post
 title:  "OTA 2018 Debrief: Cornering Compliances and Transients"
 date:   2019-01-06 18:45:00 -0400
+modified_date: 2021-04-24
 categories: [vehicle dynamics, simulation, ontario time attack]
 ---
 
@@ -54,7 +55,7 @@ Where:
 * $$L$$ is the wheelbase of the car [$$m$$]
 * $$R$$ is the radius of the turn [$$m$$]
 * $$a_y$$ is the lateral acceleration [$$m/s^2$$]
-* $$K$$ is the understeer gradient [$$rad/g$$]
+* $$K$$ is the understeer gradient [$$rad/(m/s^2)$$]
 
 Equivalently, the understeering tendency can be described as the difference in
 the front and rear slip angles.
@@ -92,17 +93,41 @@ $$\alpha_r = \frac{m_r a_y}{C_r}$$
 Substituting the front and rear slip angles yields the following definition of
 the understeer gradient.
 
-$$K = \frac{m_f}{C_f} - \frac{m_r}{C_r} = D_f - D_r$$
+$$K = \frac{m_f}{C_f} - \frac{m_r}{C_r}$$
 
 Where:
-* $$D_f$$ represents the front axle cornering compliance [$$\frac{rad}{g}$$]
-* $$D_r$$ represents the rear axle cornering compliance [$$\frac{rad}{g}$$]
+* $$D_f$$ represents the front axle cornering compliance [$$\frac{rad}{m/s^2}$$]
+* $$D_r$$ represents the rear axle cornering compliance [$$\frac{rad}{m/s^2}$$]
 
 The understeer gradient can therefore be understood as the difference between
 the front and rear cornering compliances. This definition is mathematically
 consistent with the earlier definition of the understeer gradient. Noteworthy
 of mention is the exclusion of the steer angle term in the cornering compliance
 definition of the  understeer gradient.
+
+As an aside, you will commonly find the following definition for cornering
+compliance in literature. The unit conversion is to $$rad/g$$ is implied
+through the use of $$slugs$$ and $$lbs$$.
+
+$$D = \frac{W}{C} = \frac{mg}{C}$$
+
+Where:
+* $$D$$ represents the axle cornering compliance [$$rad/g$$]
+* $$W$$ represents the vehicle weight [$$slugs$$]
+* $$C$$ represents the axle effective cornering stiffness [$$lbs/rad$$]
+
+Equivalently using SI units, this expands and simplifies to the following
+equation.
+
+$$D = \frac{mg}{Cg} = \frac{m}{C}$$
+
+Where:
+* $$D$$ represents the axle cornering compliance [$$rad/m/s^2$$]
+* $$m$$ is the axle mass [$$kg$$]
+* $$g$$ is the earth gravitational constant [$$m/s^2$$]
+* $$C$$ is the axle effective cornering stiffness [$$N/rad$$]
+* $$W$$ represents the vehicle weight [$$slugs$$]
+* $$C$$ represents the axle effective cornering stiffness [$$lbs/rad$$]
 
 # Experimental Setup
 ![ddt_civicsi](/assets/images/2019-01-06/civicsi_ddt_pits.jpg)

--- a/_posts/2019-01-06-cornering-compliance-identification.markdown
+++ b/_posts/2019-01-06-cornering-compliance-identification.markdown
@@ -92,12 +92,7 @@ $$\alpha_r = \frac{m_r a_y}{C_r}$$
 Substituting the front and rear slip angles yields the following definition of
 the understeer gradient.
 
-$$K = \frac{m_f}{C_f} - \frac{m_r}{C_r}$$
-
-Normalizing the acceleration by $$g$$ yields the cornering compliance
-definition of the understeer gradient.
-
-$$K = \frac{m_f g}{C_f} - \frac{m_r g}{C_r} = D_f - D_r$$
+$$K = \frac{m_f}{C_f} - \frac{m_r}{C_r} = D_f - D_r$$
 
 Where:
 * $$D_f$$ represents the front axle cornering compliance [$$\frac{rad}{g}$$]

--- a/_posts/2019-01-06-cornering-compliance-identification.markdown
+++ b/_posts/2019-01-06-cornering-compliance-identification.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "OTA 2018 Debrief: Cornering Compliances and Transients"
 date:   2019-01-06 18:45:00 -0400
-modified_date: 2021-04-24
+modified_date: 2021-04-28
 categories: [vehicle dynamics, simulation, ontario time attack]
 ---
 
@@ -33,6 +33,7 @@ during the racing season. In this instalment, we perform a pulse steer test to
 identify vehicle handling properties.
 
 # Transient Handling
+
 The understeer gradient is a measure of steady-state vehicle handling. However,
 in order to wholistically evaluate handling performance, it is necessary to
 analyze both steady-state and transient vehicle responses.
@@ -43,6 +44,7 @@ allows analytical examination of handling properties in both steady-state and
 transient maneuvers.
 
 # Understeer, Defined
+
 In our [last article](/jekyll/update/2018/12/01/understeer-gradient-identification.html),
 we defined understeer as the tendency for a vehicle to require more (or less)
 steering input relative to the Ackermann steer angle.  The gain due to lateral
@@ -96,7 +98,7 @@ $$\alpha_r = \frac{m_r a_y}{C_r}$$
 Substituting the front and rear slip angles yields the following definition of
 the understeer gradient.
 
-$$K = \frac{m_f}{C_f} - \frac{m_r}{C_r}$$
+$$K = \frac{m_f}{C_f} - \frac{m_r}{C_r} = D_f - D_r$$
 
 Where:
 
@@ -110,6 +112,7 @@ of mention is the exclusion of the steer angle term in the cornering compliance
 definition of the  understeer gradient.
 
 # Experimental Setup
+
 ![ddt_civicsi](/assets/images/2019-01-06/civicsi_ddt_pits.jpg)
 
 The target vehicle is a 2012 Honda Civic Si Coupe equipped with adjustable
@@ -137,6 +140,7 @@ scope of driver control, and at no time  did the driver operate the vehicle in
 an unsafe manner. Do not perform this test in an uncontrolled area._
 
 # Vehicle Parameters
+
 The following vehicle parameters are assumed for the vehicle-under-test:
 
 | Symbol | Value | Unit             | Description                       |
@@ -148,6 +152,7 @@ The following vehicle parameters are assumed for the vehicle-under-test:
 | $$K$$  | 5.5   | deg/g            | Understeer gradient (as measured) |
 
 # Results
+
 The system identification yields the following cornering compliances:
 
 * $$D_f = 9.6$$ [deg/g]
@@ -156,7 +161,7 @@ The system identification yields the following cornering compliances:
 The difference between the front and rear cornering compliances yields the
 understeer gradient:
 
-$$K = D_f - D_r = 5.5 [deg/g]$$
+$$K = D_f - D_r = 5.5\ [deg/g]$$
 
 The following graph shows the simulated response plotted against the
 experimental data acquired from in-vehicle testing.
@@ -180,6 +185,7 @@ The simulation under-predicts the peak lateral acceleration by approximately
 under-predicted in the positive case.
 
 # Summary
+
 The purpose of performing the pulse steer test is to identify the front and
 rear cornering compliances of the vehicle. Combined with the understeer
 gradient test, a simple transient vehicle model is developed.


### PR DESCRIPTION
Eric messaged me regarding discrepancies with the units of acceleration and understeer gradient. Further investigation suggested that this affects several articles relating to linear understeer theory.

## Discrepancies

* The derivation and resultant units of cornering compliance are potentially incorrect. A review of primary sources define cornering compliance as:
  * Milliken & Milliken defines cornering compliance (ex. DF, DR) as \frac{W/C}{g} with stated units of deg/g (5.53)
  * Bundorf & Leffert defines cornering compliance (ex. DF, DR) as W/C with stated units of deg/g (3) where W is in pounds
  * Cobb defines cornering compliance as \frac{mga}{(a+b)C} for the front axle with stated units of deg/g
  * Note: it is unclear at the time of writing why Milliken & Milliken uses W/C/g unlike in Bundorf & Leffert, and in Cobb. 
    * This potentially affects the EoM presented in the single track bicycle model
    * This potentially affects the cornering compliance identification article

* The units of understeer are changing across the articles. For example:
  * In the understeer gradient identification test, understeer has stated units of rad/m/s^2
  * In the cornering compliance identification test, understeer has stated units of rad/g
  * This is problematic because the units of acceleration are not changing across articles (m/s^2)
  * The equations of motion do not "bake-in" the unit conversions despite these changes

* The units of understeer change units between derivation and analysis

## Fixes

* [x] Perform all derivation work in SI units
  * The derivation should be repeatable, without and unit conversion tricks so to help the audience _repeat_ the work to gain understanding
  * We explicitly _ignore_ industry convention in the derivation for the above reason
  * In effect, we are bypassing the concerns about where the gravitational constant goes in the equations for the above reasons
* [x] Verify that the equations of motion using cornering compliance correctly resolve units from rad/g to m/s^2
  * If the equations do NOT resolve correctly, update the equations of motion
  * NOTE: the definition of cornering compliance already bakes in the unit conversions from rad/g -> N/rad. No change required.
* [x] Verify that the articles ONLY use SI units in any derivation
  * [x] Understeer gradient test
  * [x] Cornering compliance test
  * [x] On centre handling
  * [x] Parameter sensitivity