### PR TITLE
Add Jekyll gem explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-# gem "jekyll", "3.5.1"
+gem "jekyll", "3.9.2"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,9 +258,10 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll (= 3.9.2)
   jekyll-feed
   minima (~> 2.5.1)
   tzinfo-data
 
 BUNDLED WITH
-   2.3.6
+   2.3.14


### PR DESCRIPTION
The GH Action failed

```
Run bundle exec jekyll build --baseurl ""
  bundle exec jekyll build --baseurl ""
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_PAGES: true
    JEKYLL_ENV: production
bundler: command not found: jekyll
Install missing gem executables with `bundle install`
Error: Process completed with exit code 127.
```

I am going to assume that it is because Jekyll didn't get installed? Worth a try.